### PR TITLE
fix: Don't include attr attribute for principals when no attributes have been set

### DIFF
--- a/src/Api/V1/Engine/Principal.php
+++ b/src/Api/V1/Engine/Principal.php
@@ -31,12 +31,17 @@ class Principal implements \JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return [
+        $serialized = [
             "id" => $this->id,
             "roles" => $this->roles,
             "policyVersion" => $this->policyVersion,
-            "attr" => $this->attributes,
             "scope" => $this->scope
         ];
+
+        if (count($this->attributes) > 0) {
+            $serialized["attr"] = $this->attributes;
+        }
+
+        return $serialized;
     }
 }

--- a/tests/Sdk/Builder/PrincipalTest.php
+++ b/tests/Sdk/Builder/PrincipalTest.php
@@ -62,4 +62,14 @@ class PrincipalTest extends TestCase
         $this->assertEquals($this->roles[1], $principal->roles[1], "second role of the principal is not equal to the expected value");
         $this->assertEquals($this->roles[2], $principal->roles[2], "third role of the principal is not equal to the expected value");
     }
+
+    public function testPrincipalWithNoAttributesExcludesAttributeKeyInSerializedJson(): void {
+        $principal = Principal::newInstance($this->id)
+                                ->withPolicyVersion($this->policyVersion)
+                                ->withScope($this->scope)
+                                ->withRole($this->roles[0])
+                                ->withRoles(array($this->roles[1], $this->roles[2]))->toPrincipal();
+
+        $this->assertArrayNotHasKey("attr", $principal->jsonSerialize(), "the principal should not have an 'attr' key in the serialized json");
+    }
 }


### PR DESCRIPTION
As a simple fix to #32, this change excludes the `attr` key if no attributes have been set (as is done for resources).

Fixes #31 

#### Checklist 

<!-- See https://github.com/cerbos/cerbos/blob/main/CONTRIBUTING.md#submitting-pull-requests for more information. -->

- [x] The PR title has the correct prefix 
- [x] PR is linked to the corresponding issue
- [x] All commits are signed-off (`git commit -s ...`) to provide the [DCO](https://developercertificate.org/)
